### PR TITLE
docs: expand README with setup and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# NooruldeenTaffar.github.io
+# Nooruldeen Taffar Portfolio
+
+This repository contains the source code for Nooruldeen Taffar's academic portfolio. The site highlights work in health informatics and AI for cardiology and is built with [Jekyll](https://jekyllrb.com/) for deployment on GitHub Pages.
+
+## Run the site locally
+
+1. Install Ruby and Jekyll:
+   ```bash
+   gem install bundler jekyll
+   ```
+2. Serve the site:
+   ```bash
+   jekyll serve
+   ```
+3. Visit the local site at <http://localhost:4000>.
+
+## Content organization
+
+- `index.md` – homepage outlining education, research and contact information.
+- `_data/profile.yml` – personal details used across the site.
+- `_data/projects.yml` – list of featured projects displayed on the Projects page.
+- `_config.yml` – global site configuration.
+
+Key pages include:
+
+- [About](about/) – background and interests.
+- [Projects](projects/) – curated list of repositories and research.
+
+## Contributing
+
+Issues and pull requests are welcome. If you have suggestions or spot problems, please open an issue or submit a pull request.
+


### PR DESCRIPTION
## Summary
- rewrite README to explain portfolio purpose and Jekyll build instructions
- document repository structure and link to About and Projects pages
- add contribution guidance

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2e6c084833394c271b1ff45cbe2